### PR TITLE
Fix types entrypoint in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   },
   "bugs": "https://github.com/andreiduca/use-async-resource/issues",
   "main": "./lib/index.js",
-  "types": "./src/index.ts",
+  "types": "./lib/index.d.ts",
   "scripts": {
     "build": "rm -rf ./lib && tsc",
     "test": "jest --verbose --coverage"


### PR DESCRIPTION
The `types` property in ` package.json` was pointing to the source `index.ts` file instead of the corresponding declaration file in the `lib` folder. 

This was causing a couple of issues in my project, from an extra folder level when running `tsc`, to `"importsNotUsedAsValues": "error"` causing TypeScript to detect errors in this project's source files.

I've tested the fix locally with `npm link`.

Thanks for the awesome package 😉 